### PR TITLE
Prevent messaging vanished players

### DIFF
--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
@@ -1,5 +1,7 @@
 package pro.cloudnode.smp.cloudnodemsg;
 
+import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.cloudnodemsg.command.MainCommand;
@@ -31,6 +33,12 @@ public final class CloudnodeMSG extends JavaPlugin {
     @Override
     public void onDisable() {
         // Plugin shutdown logic
+    }
+
+    public static boolean isVanished(final @NotNull Player player) {
+        for (final @NotNull MetadataValue meta : player.getMetadata("vanished"))
+            if (meta.asBoolean()) return true;
+        return false;
     }
 
     private final @NotNull PluginConfig config = new PluginConfig(getConfig());

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
@@ -12,4 +12,9 @@ public final class Permission {
      * Allows reloading the plugin
      */
     public final static @NotNull String RELOAD = "cloudnodemsg.reload";
+
+    /**
+     * Allows sending messages to vanished players
+     */
+    public final static @NotNull String SEND_VANISHED = "cloudnodemsg.send.vanished";
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
@@ -28,7 +28,7 @@ public final class MessageCommand extends Command {
 
         final @NotNull Optional<@NotNull Player> recipient = Optional.ofNullable(CloudnodeMSG.getInstance().getServer()
                 .getPlayer(args[0]));
-        if (recipient.isEmpty() || CloudnodeMSG.isVanished(recipient.get())) return new PlayerNotFoundError(args[0]).send(sender);
+        if (recipient.isEmpty() || (CloudnodeMSG.isVanished(recipient.get()) && !sender.hasPermission(Permission.SEND_VANISHED))) return new PlayerNotFoundError(args[0]).send(sender);
         if (sender instanceof final @NotNull Player player && recipient.get().getUniqueId().equals(player.getUniqueId()))
             return new MessageYourselfError().send(sender);
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
@@ -28,7 +28,7 @@ public final class MessageCommand extends Command {
 
         final @NotNull Optional<@NotNull Player> recipient = Optional.ofNullable(CloudnodeMSG.getInstance().getServer()
                 .getPlayer(args[0]));
-        if (recipient.isEmpty()) return new PlayerNotFoundError(args[0]).send(sender);
+        if (recipient.isEmpty() || CloudnodeMSG.isVanished(recipient.get())) return new PlayerNotFoundError(args[0]).send(sender);
         if (sender instanceof final @NotNull Player player && recipient.get().getUniqueId().equals(player.getUniqueId()))
             return new MessageYourselfError().send(sender);
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -13,6 +13,7 @@ import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public final class ReplyCommand extends Command {
@@ -25,7 +26,14 @@ public final class ReplyCommand extends Command {
 
         final @NotNull Optional<@NotNull OfflinePlayer> recipient = Message.getReplyTo(Message.offlinePlayer(sender));
         if (recipient.isEmpty()) return new NobodyReplyError().send(sender);
-        if (!recipient.get().getUniqueId().equals(Message.console.getUniqueId()) && !recipient.get().isOnline()) return new ReplyOfflineError(Optional.ofNullable(recipient.get().getName()).orElse("Unknown Player")).send(sender);
+        if (
+            !recipient.get().getUniqueId().equals(Message.console.getUniqueId())
+            && (
+                    !recipient.get().isOnline()
+                    || CloudnodeMSG.isVanished(Objects.requireNonNull(recipient.get().getPlayer()))
+            )
+        )
+            return new ReplyOfflineError(Optional.ofNullable(recipient.get().getName()).orElse("Unknown Player")).send(sender);
 
         try {
             new Message(Message.offlinePlayer(sender), recipient.get(), String.join(" ", args)).send();

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -30,7 +30,7 @@ public final class ReplyCommand extends Command {
             !recipient.get().getUniqueId().equals(Message.console.getUniqueId())
             && (
                     !recipient.get().isOnline()
-                    || CloudnodeMSG.isVanished(Objects.requireNonNull(recipient.get().getPlayer()))
+                    || (CloudnodeMSG.isVanished(Objects.requireNonNull(recipient.get().getPlayer())) && !sender.hasPermission(Permission.SEND_VANISHED))
             )
         )
             return new ReplyOfflineError(Optional.ofNullable(recipient.get().getName()).orElse("Unknown Player")).send(sender);


### PR DESCRIPTION
Being able to send a message to a vanished player could reveal that they are indeed online and just vanished.

This PR fixes that by trying to check if the recipient is vanished.

> [!Important]
> This was specifically intended to work with [**SuperVanish**](https://www.spigotmc.org/resources/1331/) and only tested with that plugin. It *MAY* work with other vanish plugins.
> 
> The code for checking whether a player is vanished is here:
> https://github.com/cloudnode-pro/CloudnodeMSG/blob/b0096487441b315c044bf2698df6702d1c3564c4/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java#L38-L42