### PR TITLE
Add ignore functionality

### DIFF
--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
@@ -4,9 +4,11 @@ import org.bukkit.entity.Player;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.cloudnodemsg.command.IgnoreCommand;
 import pro.cloudnode.smp.cloudnodemsg.command.MainCommand;
 import pro.cloudnode.smp.cloudnodemsg.command.MessageCommand;
 import pro.cloudnode.smp.cloudnodemsg.command.ReplyCommand;
+import pro.cloudnode.smp.cloudnodemsg.command.UnIgnoreCommand;
 
 import java.util.Objects;
 
@@ -28,6 +30,8 @@ public final class CloudnodeMSG extends JavaPlugin {
         Objects.requireNonNull(getCommand("cloudnodemsg")).setExecutor(new MainCommand());
         Objects.requireNonNull(getCommand("message")).setExecutor(new MessageCommand());
         Objects.requireNonNull(getCommand("reply")).setExecutor(new ReplyCommand());
+        Objects.requireNonNull(getCommand("ignore")).setExecutor(new IgnoreCommand());
+        Objects.requireNonNull(getCommand("unignore")).setExecutor(new UnIgnoreCommand());
     }
 
     @Override

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
@@ -22,4 +22,9 @@ public final class Permission {
      * Allows ignoring and unignoring players
      */
     public final static @NotNull String IGNORE = "cloudnodemsg.ignore";
+
+    /**
+     * Player's messages are immune to ignoring
+     */
+    public final static @NotNull String IGNORE_IMMUNE = "cloudnodemsg.ignore.immune";
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
@@ -17,4 +17,9 @@ public final class Permission {
      * Allows sending messages to vanished players
      */
     public final static @NotNull String SEND_VANISHED = "cloudnodemsg.send.vanished";
+
+    /**
+     * Allows ignoring and unignoring players
+     */
+    public final static @NotNull String IGNORE = "cloudnodemsg.ignore";
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -195,5 +195,18 @@ public final class PluginConfig {
                 Placeholder.unparsed("player", player)
         );
     }
+
+    /**
+     * Target player has never joined the server
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the player's username</li></ul>
+     *
+     * @param player The player's username
+     */
+    public @NotNull Component neverJoined(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("errors.never-joined")),
+                Placeholder.unparsed("player", player)
+        );
+    }
 }
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -58,6 +58,32 @@ public final class PluginConfig {
     }
 
     /**
+     * Player has successfully been ignored
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the username of the player</li></ul>
+     *
+     * @param player The username of the player
+     */
+    public @NotNull Component ignored(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("ignored")),
+                Placeholder.unparsed("player", player)
+        );
+    }
+
+    /**
+     * Player has successfully been unignored
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the username of the player</li></ul>
+     *
+     * @param player The username of the player
+     */
+    public @NotNull Component unignored(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("unignored")),
+                Placeholder.unparsed("player", player)
+        );
+    }
+
+    /**
      * Command usage format
      * <p>Placeholders:</p>
      * <ul>
@@ -133,6 +159,26 @@ public final class PluginConfig {
      */
     public @NotNull Component replyOffline(final @NotNull String player) {
         return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("errors.reply-offline")),
+                Placeholder.unparsed("player", player)
+        );
+    }
+
+    /**
+     * Only players can use this command
+     */
+    public @NotNull Component notPlayer() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("errors.not-player")));
+    }
+
+    /**
+     * That player is not ignored
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the player's username</li></ul>
+     *
+     * @param player The player's username
+     */
+    public @NotNull Component notIgnored(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("errors.not-ignored")),
                 Placeholder.unparsed("player", player)
         );
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -182,5 +182,18 @@ public final class PluginConfig {
                 Placeholder.unparsed("player", player)
         );
     }
+
+    /**
+     * Player cannot be ignored
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the player's username</li></ul>
+     *
+     * @param player The player's username
+     */
+    public @NotNull Component cannotIgnore(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("errors.cannot-ignore")),
+                Placeholder.unparsed("player", player)
+        );
+    }
 }
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/Command.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/Command.java
@@ -7,7 +7,7 @@ import org.bukkit.command.TabCompleter;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class Command implements TabCompleter, CommandExecutor {
-    public boolean sendMessage(final @NotNull Audience recipient, final @NotNull Component message) {
+    public static boolean sendMessage(final @NotNull Audience recipient, final @NotNull Component message) {
         recipient.sendMessage(message);
         return true;
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
@@ -1,0 +1,46 @@
+package pro.cloudnode.smp.cloudnodemsg.command;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+import pro.cloudnode.smp.cloudnodemsg.Permission;
+import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
+import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
+import pro.cloudnode.smp.cloudnodemsg.message.Message;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public final class IgnoreCommand extends Command {
+    public static final @NotNull String usage = "<player>";
+
+    @Override
+    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+        if (!sender.hasPermission(Permission.IGNORE)) return new NoPermissionError().send(sender);
+        if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
+        if (args.length == 0) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
+        final @NotNull OfflinePlayer target = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
+        if (Message.isIgnored(player, target)) return unignore(player, target);
+        return ignore(player, target);
+    }
+
+    public static boolean ignore(final @NotNull Player player, final @NotNull OfflinePlayer target) {
+        Message.ignore(player, target);
+        return sendMessage(player, CloudnodeMSG.getInstance().config().ignored(Optional.ofNullable(target.getName()).orElse("Unknown Player")));
+    }
+
+    public static boolean unignore(final @NotNull Player player, final @NotNull OfflinePlayer target) {
+        Message.unignore(player, target);
+        return sendMessage(player, CloudnodeMSG.getInstance().config().unignored(Optional.ofNullable(target.getName()).orElse("Unknown Player")));
+    }
+
+    @Override
+    public @Nullable List<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
+        if (args.length == 1 && sender.hasPermission(Permission.IGNORE) && sender instanceof Player) return null;
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
@@ -7,12 +7,14 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
+import pro.cloudnode.smp.cloudnodemsg.error.CannotIgnoredError;
 import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
 import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public final class IgnoreCommand extends Command {
@@ -22,13 +24,14 @@ public final class IgnoreCommand extends Command {
     public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
         if (!sender.hasPermission(Permission.IGNORE)) return new NoPermissionError().send(sender);
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
-        if (args.length == 0) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
+        if (args.length == 0) return sendMessage(player, CloudnodeMSG.getInstance().config().usage(label, usage));
         final @NotNull OfflinePlayer target = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
         if (Message.isIgnored(player, target)) return unignore(player, target);
         return ignore(player, target);
     }
 
     public static boolean ignore(final @NotNull Player player, final @NotNull OfflinePlayer target) {
+        if (target.isOnline() && Objects.requireNonNull(target.getPlayer()).hasPermission(Permission.IGNORE_IMMUNE)) return new CannotIgnoredError(Optional.ofNullable(target.getName()).orElse("Unknown Player")).send(player);
         Message.ignore(player, target);
         return sendMessage(player, CloudnodeMSG.getInstance().config().ignored(Optional.ofNullable(target.getName()).orElse("Unknown Player")));
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
 import pro.cloudnode.smp.cloudnodemsg.error.CannotIgnoredError;
+import pro.cloudnode.smp.cloudnodemsg.error.NeverJoinedError;
 import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
 import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
@@ -32,6 +33,7 @@ public final class IgnoreCommand extends Command {
 
     public static boolean ignore(final @NotNull Player player, final @NotNull OfflinePlayer target) {
         if (target.isOnline() && Objects.requireNonNull(target.getPlayer()).hasPermission(Permission.IGNORE_IMMUNE)) return new CannotIgnoredError(Optional.ofNullable(target.getName()).orElse("Unknown Player")).send(player);
+        if (!target.hasPlayedBefore()) return new NeverJoinedError(Optional.ofNullable(target.getName()).orElse("Unknown Player")).send(player);
         Message.ignore(player, target);
         return sendMessage(player, CloudnodeMSG.getInstance().config().ignored(Optional.ofNullable(target.getName()).orElse("Unknown Player")));
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/UnIgnoreCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/UnIgnoreCommand.java
@@ -1,0 +1,45 @@
+package pro.cloudnode.smp.cloudnodemsg.command;
+
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+import pro.cloudnode.smp.cloudnodemsg.Permission;
+import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
+import pro.cloudnode.smp.cloudnodemsg.error.NotIgnoredError;
+import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
+import pro.cloudnode.smp.cloudnodemsg.message.Message;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class UnIgnoreCommand extends Command {
+    public static final @NotNull String usage = "<player>";
+
+    @Override
+    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+        if (!sender.hasPermission(Permission.IGNORE)) return new NoPermissionError().send(sender);
+        if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
+        if (args.length == 0) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
+        final @NotNull OfflinePlayer target = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
+        if (Message.isIgnored(player, target)) return IgnoreCommand.unignore(player, target);
+        return new NotIgnoredError(args[0]).send(sender);
+    }
+
+    @Override
+    public @Nullable List<@NotNull String> onTabComplete(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, final @NotNull String @NotNull [] args) {
+        if (args.length == 1 && sender.hasPermission(Permission.IGNORE) && sender instanceof final @NotNull Player player) {
+            final @NotNull HashSet<@NotNull UUID> ignored = Message.getIgnored(player);
+            final @NotNull Server server = CloudnodeMSG.getInstance().getServer();
+            return new ArrayList<>(ignored.stream().map(u -> server.getOfflinePlayer(u).getName())
+                    .filter(Objects::nonNull).filter(n -> n.toLowerCase().startsWith(args[0].toLowerCase())).toList());
+        }
+        return new ArrayList<>();
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/CannotIgnoredError.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/CannotIgnoredError.java
@@ -1,0 +1,13 @@
+package pro.cloudnode.smp.cloudnodemsg.error;
+
+import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+
+/**
+ * Player cannot be ignored
+ */
+public final class CannotIgnoredError extends Error {
+    public CannotIgnoredError(final @NotNull String player) {
+        super(CloudnodeMSG.getInstance().config().cannotIgnore(player));
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/NeverJoinedError.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/NeverJoinedError.java
@@ -1,0 +1,13 @@
+package pro.cloudnode.smp.cloudnodemsg.error;
+
+import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+
+/**
+ * Target player has never joined the server
+ */
+public final class NeverJoinedError extends Error {
+    public NeverJoinedError(final @NotNull String player) {
+        super(CloudnodeMSG.getInstance().config().neverJoined(player));
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/NotIgnoredError.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/NotIgnoredError.java
@@ -1,0 +1,13 @@
+package pro.cloudnode.smp.cloudnodemsg.error;
+
+import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+
+/**
+ * That player is not ignored
+ */
+public final class NotIgnoredError extends Error {
+    public NotIgnoredError(final @NotNull String player) {
+        super(CloudnodeMSG.getInstance().config().notIgnored(player));
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/NotPlayerError.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/NotPlayerError.java
@@ -1,0 +1,12 @@
+package pro.cloudnode.smp.cloudnodemsg.error;
+
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+
+/**
+ * Only players can use this command
+ */
+public final class NotPlayerError extends Error {
+    public NotPlayerError() {
+        super(CloudnodeMSG.getInstance().config().notPlayer());
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -10,6 +10,7 @@ import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+import pro.cloudnode.smp.cloudnodemsg.Permission;
 import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
 
 import java.util.Arrays;
@@ -37,7 +38,11 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         sendMessage(sender, CloudnodeMSG.getInstance().config().outgoing(senderUsername, recipientUsername, message));
         setReplyTo(sender, recipient);
 
-        if (recipient.isOnline() && Message.isIgnored(Objects.requireNonNull(recipient.getPlayer()), sender)) return;
+        if (
+                (recipient.isOnline() && Message.isIgnored(Objects.requireNonNull(recipient.getPlayer()), sender))
+                &&
+                (sender.isOnline() && !Objects.requireNonNull(sender.getPlayer()).hasPermission(Permission.IGNORE_IMMUNE))
+        ) return;
         sendMessage(recipient, CloudnodeMSG.getInstance().config()
                 .incoming(senderUsername, recipientUsername, message));
         setReplyTo(recipient, sender);

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -5,12 +5,15 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -32,10 +35,11 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         final @NotNull String recipientUsername = playerOrServerUsername(this.recipient);
 
         sendMessage(sender, CloudnodeMSG.getInstance().config().outgoing(senderUsername, recipientUsername, message));
+        setReplyTo(sender, recipient);
+
+        if (recipient.isOnline() && Message.isIgnored(Objects.requireNonNull(recipient.getPlayer()), sender)) return;
         sendMessage(recipient, CloudnodeMSG.getInstance().config()
                 .incoming(senderUsername, recipientUsername, message));
-
-        setReplyTo(sender, recipient);
         setReplyTo(recipient, sender);
     }
 
@@ -77,5 +81,52 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         if (player.getUniqueId().equals(console.getUniqueId())) consoleReply = null;
         else if (player.isOnline())
             Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer().remove(REPLY_TO);
+    }
+
+    public static final @NotNull NamespacedKey IGNORED_PLAYERS = new NamespacedKey(CloudnodeMSG.getInstance(), "ignored");
+
+    /**
+     * Get UUID set of ignored players from PDC string
+     *
+     * @param player The player
+     */
+    public static @NotNull HashSet<@NotNull UUID> getIgnored(final @NotNull Player player) {
+        final @NotNull Optional<@NotNull String> str = Optional.ofNullable(player.getPersistentDataContainer().get(IGNORED_PLAYERS, PersistentDataType.STRING));
+        return str.map(s -> new HashSet<>(Arrays.stream(s.split(";")).filter(e -> !e.isEmpty()).map(UUID::fromString).toList()))
+                .orElseGet(HashSet::new);
+    }
+
+    /**
+     * Check if a player is ignored
+     *
+     * @param player The player
+     * @param ignored The ignored player
+     */
+    public static boolean isIgnored(final @NotNull Player player, final @NotNull OfflinePlayer ignored) {
+        return getIgnored(player).contains(ignored.getUniqueId());
+    }
+
+    /**
+     * Ignore a player
+     *
+     * @param player The player
+     * @param ignore The player to ignore
+     */
+    public static void ignore(final @NotNull Player player, final @NotNull OfflinePlayer ignore) {
+        final @NotNull HashSet<@NotNull UUID> ignoredPlayers = getIgnored(player);
+        ignoredPlayers.add(ignore.getUniqueId());
+        player.getPersistentDataContainer().set(IGNORED_PLAYERS, PersistentDataType.STRING, String.join(";", ignoredPlayers.stream().map(UUID::toString).toList()));
+    }
+
+    /**
+     * Unignore a player
+     *
+     * @param player The player
+     * @param ignored The player to unignore
+     */
+    public static void unignore(final @NotNull Player player, final @NotNull OfflinePlayer ignored) {
+        final @NotNull HashSet<@NotNull UUID> ignoredPlayers = getIgnored(player);
+        ignoredPlayers.remove(ignored.getUniqueId());
+        player.getPersistentDataContainer().set(IGNORED_PLAYERS, PersistentDataType.STRING, String.join(";", ignoredPlayers.stream().map(UUID::toString).toList()));
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -59,3 +59,8 @@ errors:
     # Placeholders:
     #  <player> - the player's username
     not-ignored: "<red>(!) You are not ignoring that player.</red>"
+
+    # Player cannot be ignored
+    # Placeholders:
+    #  <player> - the player's username
+    cannot-ignore: "<red>(!) You cannot ignore <gray><player></gray>.</red>"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -64,3 +64,8 @@ errors:
     # Placeholders:
     #  <player> - the player's username
     cannot-ignore: "<red>(!) You cannot ignore <gray><player></gray>.</red>"
+
+    # Target player has never joined the server
+    # Placeholders:
+    #  <player> - the player's username
+    never-joined: "<red>(!) <gray><player></gray> has never joined this server.</red>"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,15 @@ incoming: '<click:suggest_command:/msg <sender> ><dark_gray>[<#60a5fa><sender></
 # Same placeholders as incoming
 outgoing: '<click:suggest_command:/msg <recipient> ><dark_gray>[<#93c5fd>me</#93c5fd> <white>-></white> <#60a5fa><recipient></#60a5fa>]</dark_gray></click> <reset><#dbeafe><message></#dbeafe>'
 
+# Player has successfully been ignored
+# Placeholders:
+#  <player> - the player's username
+ignored: "<green>(!) You will no longer see messages from <gray><player></gray>.</green>"
+
+# Player has successfully been unignored
+# Same placeholders as ignored
+unignored: "<yellow>(!) You are no longer ignoring <gray><player></gray>.</yellow>"
+
 # Name for console/server that should appear as <sender> or <recipient> in messages
 console-name: "Server"
 
@@ -42,3 +51,11 @@ errors:
     # Placeholders:
     #  <player> - the player's username
     reply-offline: "<red>(!) Player <gray><player></gray> is no longer online.</red>"
+
+    # Only players can use this command
+    not-player: "<red>(!) You must be a player to use this command.</red>"
+
+    # That player is not ignored
+    # Placeholders:
+    #  <player> - the player's username
+    not-ignored: "<red>(!) You are not ignoring that player.</red>"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,3 +15,11 @@ commands:
     cloudnodemsg:
         description: CloudnodeMSG
         usage: /<command>
+    ignore:
+        description: Ignore a player
+        usage: /<command> <player>
+        aliases: [ "block" ]
+    unignore:
+        description: Unignore a player
+        usage: /<command> <player>
+        aliases: [ "unblock" ]


### PR DESCRIPTION
Ignoring is only implemented for messages sent using this plugin. No control is exerted over regular chat.

The `/ignore <player>` command toggles whether you are ignoring a player.

The `/unignore <player>` command only works for unignoring a player (and the tab completions are only ignored players).

There is also ignore immunity. Players with immunity cannot be ignored, and if they were marked as ignored by someone, their messages can still always be seen.