### PR TITLE
Make our commands async

### DIFF
--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/Command.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/Command.java
@@ -3,12 +3,24 @@ package pro.cloudnode.smp.cloudnodemsg.command;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 
 public abstract class Command implements TabCompleter, CommandExecutor {
     public static boolean sendMessage(final @NotNull Audience recipient, final @NotNull Component message) {
         recipient.sendMessage(message);
+        return true;
+    }
+
+    public abstract boolean run(final @NotNull CommandSender sender, final @NotNull String label, final @NotNull String[] args);
+
+    @Override
+    public final boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+        CloudnodeMSG.getInstance().getServer().getScheduler().runTaskAsynchronously(CloudnodeMSG.getInstance(), () -> {
+            final boolean ignored = run(sender, label, args);
+        });
         return true;
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/IgnoreCommand.java
@@ -22,7 +22,7 @@ public final class IgnoreCommand extends Command {
     public static final @NotNull String usage = "<player>";
 
     @Override
-    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+    public boolean run(final @NotNull CommandSender sender, final @NotNull String label, @NotNull String @NotNull [] args) {
         if (!sender.hasPermission(Permission.IGNORE)) return new NoPermissionError().send(sender);
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
         if (args.length == 0) return sendMessage(player, CloudnodeMSG.getInstance().config().usage(label, usage));

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MainCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MainCommand.java
@@ -15,7 +15,7 @@ import java.util.List;
 public final class MainCommand extends Command {
 
     @Override
-    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+    public boolean run(final @NotNull CommandSender sender, final @NotNull String label, @NotNull String @NotNull [] args) {
         if (args.length == 1) switch (args[0]) {
             case "reload", "rl" -> {
                 return reload(sender);

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
@@ -21,7 +21,7 @@ public final class MessageCommand extends Command {
     public static final @NotNull String usage = "<player> <message>";
 
     @Override
-    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+    public boolean run(final @NotNull CommandSender sender, final @NotNull String label, @NotNull String @NotNull [] args) {
         if (!sender.hasPermission(Permission.USE)) return new NoPermissionError().send(sender);
         if (args.length == 0) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
         if (args.length == 1) return sendMessage(sender, CloudnodeMSG.getInstance().config()

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -20,7 +20,7 @@ public final class ReplyCommand extends Command {
     public static final @NotNull String usage = "<message>";
 
     @Override
-    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+    public boolean run(final @NotNull CommandSender sender, final @NotNull String label, @NotNull String @NotNull [] args) {
         if (!sender.hasPermission(Permission.USE)) return new NoPermissionError().send(sender);
         if (args.length == 0) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/UnIgnoreCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/UnIgnoreCommand.java
@@ -23,7 +23,7 @@ public final class UnIgnoreCommand extends Command {
     public static final @NotNull String usage = "<player>";
 
     @Override
-    public boolean onCommand(final @NotNull CommandSender sender, final @NotNull org.bukkit.command.Command command, final @NotNull String label, @NotNull String @NotNull [] args) {
+    public boolean run(final @NotNull CommandSender sender, final @NotNull String label, @NotNull String @NotNull [] args) {
         if (!sender.hasPermission(Permission.IGNORE)) return new NoPermissionError().send(sender);
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
         if (args.length == 0) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));


### PR DESCRIPTION
By default, commands are executed on the main thread. Some slow operations like looking up UUIDs from usernames (which sends a blocking web request) can lag the server a lot.

The following video showcases how by running our commands on a separate thread we can avoid slowing down the server.
[Screencast from 2024-01-09 02-42-57.webm](https://github.com/cloudnode-pro/CloudnodeMSG/assets/66572326/e1dbe7ca-2df7-473f-8e49-33d7b94ab01f)

Fair disclosure: could be this slow in the video due to my slow internet