### PR TITLE
Implements an option to toggle private messages

### DIFF
--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
@@ -5,6 +5,7 @@ import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.cloudnodemsg.command.MainCommand;
 import pro.cloudnode.smp.cloudnodemsg.command.MessageCommand;
 import pro.cloudnode.smp.cloudnodemsg.command.ReplyCommand;
+import pro.cloudnode.smp.cloudnodemsg.command.ToggleMessageCommand;
 
 import java.util.Objects;
 
@@ -26,6 +27,7 @@ public final class CloudnodeMSG extends JavaPlugin {
         Objects.requireNonNull(getCommand("cloudnodemsg")).setExecutor(new MainCommand());
         Objects.requireNonNull(getCommand("message")).setExecutor(new MessageCommand());
         Objects.requireNonNull(getCommand("reply")).setExecutor(new ReplyCommand());
+        Objects.requireNonNull(getCommand("togglemsg")).setExecutor(new ToggleMessageCommand());
     }
 
     @Override

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/CloudnodeMSG.java
@@ -31,7 +31,8 @@ public final class CloudnodeMSG extends JavaPlugin {
 
         Objects.requireNonNull(getCommand("cloudnodemsg")).setExecutor(new MainCommand());
         Objects.requireNonNull(getCommand("message")).setExecutor(new MessageCommand());
-        Objects.requireNonNull(getCommand("reply")).setExecutor(new ReplyCommand());Objects.requireNonNull(getCommand("ignore")).setExecutor(new IgnoreCommand());
+        Objects.requireNonNull(getCommand("reply")).setExecutor(new ReplyCommand());
+        Objects.requireNonNull(getCommand("ignore")).setExecutor(new IgnoreCommand());
         Objects.requireNonNull(getCommand("unignore")).setExecutor(new UnIgnoreCommand());
         Objects.requireNonNull(getCommand("togglemsg")).setExecutor(new ToggleMessageCommand());
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
@@ -18,4 +18,8 @@ public final class Permission {
      */
     public final static @NotNull String TOGGLE = "cloudnodemsg.toggle";
 
+    /**
+     * Allows using the /togglemsg command for others
+     */
+    public final static @NotNull String TOGGLE_OTHER = "cloudnodemsg.toggle.other";
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
@@ -12,4 +12,10 @@ public final class Permission {
      * Allows reloading the plugin
      */
     public final static @NotNull String RELOAD = "cloudnodemsg.reload";
+
+    /**
+     * Allows using the /togglemsg command
+     */
+    public final static @NotNull String TOGGLE = "cloudnodemsg.toggle";
+
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/Permission.java
@@ -37,4 +37,9 @@ public final class Permission {
      * Allows using the /togglemsg command for others
      */
     public final static @NotNull String TOGGLE_OTHER = "cloudnodemsg.toggle.other";
+
+    /**
+     * Allows to send private message even when the target have their private messages toggled
+     */
+    public final static @NotNull String TOGGLE_BYPASS = "cloudnodemsg.toggle.bypass";
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -116,7 +116,7 @@ public final class PluginConfig {
     }
 
     public @NotNull Component toggleDisable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-disable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-disable")));
     }
 
     /**
@@ -127,13 +127,13 @@ public final class PluginConfig {
      * @param player the player's username
      */
     public @NotNull Component toggleDisableOther(final @NotNull String player) {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-disable-other")),
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-disable-other")),
                 Placeholder.unparsed("player", player)
         );
     }
 
     public @NotNull Component toggleEnable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-enable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-enable")));
     }
 
     /**
@@ -144,7 +144,7 @@ public final class PluginConfig {
      * @param player the player's username
      */
     public @NotNull Component toggleEnableOther(final @NotNull String player) {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-enable-other")),
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-enable-other")),
                 Placeholder.unparsed("player", player)
         );
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -106,6 +106,10 @@ public final class PluginConfig {
         );
     }
 
+    public @NotNull Component toggleEnable() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable")));
+    }
+
      * No permission
      */
     public @NotNull Component noPermission() {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -116,7 +116,7 @@ public final class PluginConfig {
     }
 
     public @NotNull Component toggleDisable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-disable")));
     }
 
     /**
@@ -127,13 +127,13 @@ public final class PluginConfig {
      * @param player the player's username
      */
     public @NotNull Component toggleDisableOther(final @NotNull String player) {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable-other")),
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-disable-other")),
                 Placeholder.unparsed("player", player)
         );
     }
 
     public @NotNull Component toggleEnable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-enable")));
     }
 
     /**
@@ -144,7 +144,7 @@ public final class PluginConfig {
      * @param player the player's username
      */
     public @NotNull Component toggleEnableOther(final @NotNull String player) {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable-other")),
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("togglemsg-enable-other")),
                 Placeholder.unparsed("player", player)
         );
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -116,7 +116,7 @@ public final class PluginConfig {
     }
 
     public @NotNull Component toggleDisable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.disable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.disable.message")));
     }
 
     /**
@@ -133,7 +133,7 @@ public final class PluginConfig {
     }
 
     public @NotNull Component toggleEnable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.enable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.enable.message")));
     }
 
     /**

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -110,6 +110,20 @@ public final class PluginConfig {
         return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable")));
     }
 
+    /**
+     * The player you enabled private messages
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the player's username</li></ul>
+     *
+     * @param player the player's username
+     */
+    public @NotNull Component toggleEnableOther(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable-other")),
+                Placeholder.unparsed("player", player)
+        );
+    }
+
+    /**
      * No permission
      */
     public @NotNull Component noPermission() {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -94,6 +94,18 @@ public final class PluginConfig {
     }
 
     /**
+     * The player you disabled private messages
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the player's username</li></ul>
+     *
+     * @param player the player's username
+     */
+    public @NotNull Component toggleDisableOther(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable-other")),
+                Placeholder.unparsed("player", player)
+        );
+    }
+
      * No permission
      */
     public @NotNull Component noPermission() {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -89,6 +89,10 @@ public final class PluginConfig {
         return Objects.requireNonNull(config.getString("console-name"));
     }
 
+    public @NotNull Component toggleDisable() {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-disable")));
+    }
+
     /**
      * No permission
      */

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -116,7 +116,7 @@ public final class PluginConfig {
     }
 
     public @NotNull Component toggleDisable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-disable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.disable")));
     }
 
     /**
@@ -127,13 +127,13 @@ public final class PluginConfig {
      * @param player the player's username
      */
     public @NotNull Component toggleDisableOther(final @NotNull String player) {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-disable-other")),
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.disable.other")),
                 Placeholder.unparsed("player", player)
         );
     }
 
     public @NotNull Component toggleEnable() {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-enable")));
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.enable")));
     }
 
     /**
@@ -144,7 +144,7 @@ public final class PluginConfig {
      * @param player the player's username
      */
     public @NotNull Component toggleEnableOther(final @NotNull String player) {
-        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle-message-enable-other")),
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("toggle.enable.other")),
                 Placeholder.unparsed("player", player)
         );
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -120,7 +120,7 @@ public final class PluginConfig {
     }
 
     /**
-     * The player you disabled private messages
+     * Player's private messages have been toggled off
      * <p>Placeholders:</p>
      * <ul><li>{@code <player>} - the player's username</li></ul>
      *
@@ -137,7 +137,7 @@ public final class PluginConfig {
     }
 
     /**
-     * The player you enabled private messages
+     * Player's private messages have been toggled on
      * <p>Placeholders:</p>
      * <ul><li>{@code <player>} - the player's username</li></ul>
      *

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -242,5 +242,18 @@ public final class PluginConfig {
                 Placeholder.unparsed("player", player)
         );
     }
+
+    /**
+     * Target player have disabled their incoming private messages.
+     * <p>Placeholders:</p>
+     * <ul><li>{@code <player>} - the player's username</li></ul>
+     *
+     * @param player The player's username
+     */
+    public @NotNull Component incomingDisabled(final @NotNull String player) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("errors.incoming-disabled")),
+                Placeholder.unparsed("player", player)
+        );
+    }
 }
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
@@ -33,7 +33,7 @@ public final class MessageCommand extends Command {
         if (recipient.isEmpty() || (CloudnodeMSG.isVanished(recipient.get()) && !sender.hasPermission(Permission.SEND_VANISHED))) return new PlayerNotFoundError(args[0]).send(sender);
         if (sender instanceof final @NotNull Player player && recipient.get().getUniqueId().equals(player.getUniqueId()))
             return new MessageYourselfError().send(sender);
-        if (!Message.isIncomeEnabled(recipient.get()) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(recipient.get().getName()).send(sender);
+        if (!Message.isIncomingEnabled(recipient.get()) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(recipient.get().getName()).send(sender);
 
         try {
             new Message(Message.offlinePlayer(sender), recipient.get(), String.join(" ", Arrays.copyOfRange(args, 1, args.length))).send();

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/MessageCommand.java
@@ -10,6 +10,7 @@ import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.error.MessageYourselfError;
 import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
 import pro.cloudnode.smp.cloudnodemsg.error.PlayerNotFoundError;
+import pro.cloudnode.smp.cloudnodemsg.error.PlayerHasIncomingDisabledError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ public final class MessageCommand extends Command {
         if (recipient.isEmpty() || (CloudnodeMSG.isVanished(recipient.get()) && !sender.hasPermission(Permission.SEND_VANISHED))) return new PlayerNotFoundError(args[0]).send(sender);
         if (sender instanceof final @NotNull Player player && recipient.get().getUniqueId().equals(player.getUniqueId()))
             return new MessageYourselfError().send(sender);
+        if (!Message.isIncomeEnabled(recipient.get()) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(recipient.get().getName()).send(sender);
 
         try {
             new Message(Message.offlinePlayer(sender), recipient.get(), String.join(" ", Arrays.copyOfRange(args, 1, args.length))).send();

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -5,7 +5,11 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
-import pro.cloudnode.smp.cloudnodemsg.error.*;
+import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
+import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
+import pro.cloudnode.smp.cloudnodemsg.error.NobodyReplyError;
+import pro.cloudnode.smp.cloudnodemsg.error.ReplyOfflineError;
+import pro.cloudnode.smp.cloudnodemsg.error.PlayerHasIncomingDisabledError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.ArrayList;

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -5,10 +5,7 @@ import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
-import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
-import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
-import pro.cloudnode.smp.cloudnodemsg.error.NobodyReplyError;
-import pro.cloudnode.smp.cloudnodemsg.error.ReplyOfflineError;
+import pro.cloudnode.smp.cloudnodemsg.error.*;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.ArrayList;
@@ -26,6 +23,7 @@ public final class ReplyCommand extends Command {
 
         final @NotNull Optional<@NotNull OfflinePlayer> recipient = Message.getReplyTo(Message.offlinePlayer(sender));
         if (recipient.isEmpty()) return new NobodyReplyError().send(sender);
+        if (!Message.isIncomeEnabled(Objects.requireNonNull(recipient.get().getPlayer())) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(Objects.requireNonNull(recipient.get().getName())).send(sender);
         if (
             !recipient.get().getUniqueId().equals(Message.console.getUniqueId())
             && (

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -27,7 +27,7 @@ public final class ReplyCommand extends Command {
 
         final @NotNull Optional<@NotNull OfflinePlayer> recipient = Message.getReplyTo(Message.offlinePlayer(sender));
         if (recipient.isEmpty()) return new NobodyReplyError().send(sender);
-        if (!Message.isIncomeEnabled(Objects.requireNonNull(recipient.get().getPlayer())) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(Objects.requireNonNull(recipient.get().getName())).send(sender);
+        if (!Message.isIncomingEnabled(Objects.requireNonNull(recipient.get().getPlayer())) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(Objects.requireNonNull(recipient.get().getName())).send(sender);
         if (
             !recipient.get().getUniqueId().equals(Message.console.getUniqueId())
             && (

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -13,7 +13,6 @@ import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 public class ToggleMessageCommand extends Command {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -34,6 +34,7 @@ public class ToggleMessageCommand extends Command {
 
             return true;
         }
+        if (args.length > 1) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
 
         if (Message.isIncomeEnabled(player)) {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -16,8 +16,6 @@ import java.util.List;
 import java.util.Optional;
 
 public class ToggleMessageCommand extends Command {
-    public static final @NotNull String usage = "<player>";
-
     @Override
     public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
         if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER)))
@@ -40,7 +38,6 @@ public class ToggleMessageCommand extends Command {
 
             return true;
         }
-        if (args.length > 1) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
 
         if (Message.isIncomingEnabled(player)) {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -28,14 +28,14 @@ public class ToggleMessageCommand extends Command {
             if (recipient.getPlayer() == null)
                 return new NeverJoinedError(Optional.ofNullable(recipient.getName()).orElse("Unknown Player")).send(sender);
 
-            if (Message.isIncomeEnabled(recipient.getPlayer())) {
-                Message.incomeDisable(recipient.getPlayer());
+            if (Message.isIncomingEnabled(recipient.getPlayer())) {
+                Message.incomingDisable(recipient.getPlayer());
                 sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
 
                 return true;
             }
 
-            Message.incomeEnable(recipient.getPlayer());
+            Message.incomingEnable(recipient.getPlayer());
             sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
 
             return true;
@@ -43,14 +43,14 @@ public class ToggleMessageCommand extends Command {
         if (args.length > 1) return sendMessage(sender, CloudnodeMSG.getInstance().config().usage(label, usage));
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
 
-        if (Message.isIncomeEnabled(player)) {
-            Message.incomeDisable(player);
+        if (Message.isIncomingEnabled(player)) {
+            Message.incomingDisable(player);
             sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisable());
 
             return true;
         }
 
-        Message.incomeEnable(player);
+        Message.incomingEnable(player);
         sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnable());
 
         return true;

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -21,23 +21,31 @@ public class ToggleMessageCommand extends Command {
         if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
         if (args.length == 1) {
-            final @NotNull OfflinePlayer recipient = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
+            final @NotNull Player recipient = Objects.requireNonNull(CloudnodeMSG.getInstance().getServer().getPlayer(args[0]));
 
-            Message.setNoIncoming(recipient);
-            sendMessage(sender, Message.getNoIncoming(recipient) ?
-                    CloudnodeMSG.getInstance().config().toggleDisableOther(Objects.requireNonNull(recipient.getName())) :
-                    CloudnodeMSG.getInstance().config().toggleEnableOther(Objects.requireNonNull(recipient.getName()))
-            );
+            if (!Message.isIncomeEnabled(recipient)) {
+                Message.incomeDisable(recipient);
+                sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Objects.requireNonNull(recipient.getName())));
+
+                return true;
+            }
+
+            Message.incomeEnable(recipient);
+            sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnableOther(Objects.requireNonNull(recipient.getName())));
+
             return true;
         }
 
-        final @NotNull OfflinePlayer player = Message.offlinePlayer(sender);
+        if (Message.isIncomeEnabled(player)) {
+            Message.incomeDisable(player);
+            sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisable());
 
-        Message.setNoIncoming(player);
-        sendMessage(sender, Message.getNoIncoming(player) ?
-                CloudnodeMSG.getInstance().config().toggleDisable() :
-                CloudnodeMSG.getInstance().config().toggleEnable()
-        );
+            return true;
+        }
+
+        Message.incomeEnable(player);
+        sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnable());
+
         return true;
     }
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -29,8 +29,10 @@ public class ToggleMessageCommand extends Command {
             return true;
         }
 
-        Message.setNoIncoming(Objects.requireNonNull(Message.offlinePlayer(sender)));
-        sendMessage(sender, Message.getNoIncoming(Message.offlinePlayer(sender)) ?
+        final @NotNull OfflinePlayer player = Message.offlinePlayer(sender);
+
+        Message.setNoIncoming(player);
+        sendMessage(sender, Message.getNoIncoming(player) ?
                 CloudnodeMSG.getInstance().config().toggleDisable() :
                 CloudnodeMSG.getInstance().config().toggleEnable()
         );

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -40,7 +40,7 @@ public class ToggleMessageCommand extends Command {
     }
 
     @Override
-    public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, org.bukkit.command.@NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, org.bukkit.command.@NotNull Command command, @NotNull String s, @NotNull String[] strings) {
         return null;
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -20,11 +20,13 @@ public class ToggleMessageCommand extends Command {
 
     @Override
     public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
-        if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
+        if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER)))
+            return new NoPermissionError().send(sender);
         if (args.length == 1) {
             final @NotNull OfflinePlayer recipient = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
 
-            if (recipient.getPlayer() == null) return new NeverJoinedError(Optional.ofNullable(recipient.getName()).orElse("Unknown Player")).send(sender);
+            if (recipient.getPlayer() == null)
+                return new NeverJoinedError(Optional.ofNullable(recipient.getName()).orElse("Unknown Player")).send(sender);
 
             if (Message.isIncomeEnabled(recipient.getPlayer())) {
                 Message.incomeDisable(recipient.getPlayer());

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -14,8 +14,9 @@ import java.util.Objects;
 
 public class ToggleMessageCommand extends Command {
     public static final @NotNull String usage = "<player>";
+
     @Override
-    public boolean onCommand(@NotNull CommandSender sender, org.bukkit.command.@NotNull Command command, @NotNull String label, @NotNull String[] args) {
+    public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
         if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
         if (args.length == 1) {
             final @NotNull OfflinePlayer recipient = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -1,5 +1,6 @@
 package pro.cloudnode.smp.cloudnodemsg.command;
 
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -13,6 +14,7 @@ import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class ToggleMessageCommand extends Command {
     public static final @NotNull String usage = "<player>";
@@ -21,18 +23,19 @@ public class ToggleMessageCommand extends Command {
     public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
         if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
         if (args.length == 1) {
-            final @NotNull Player recipient = Objects.requireNonNull(CloudnodeMSG.getInstance().getServer().getPlayer(args[0]));
+            final @NotNull OfflinePlayer recipient = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
 
-            if (Message.isIncomeEnabled(recipient)) {
-                Message.incomeDisable(recipient);
-                sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Objects.requireNonNull(recipient.getName())));
             if (recipient.getPlayer() == null) return new NeverJoinedError(Optional.ofNullable(recipient.getName()).orElse("Unknown Player")).send(sender);
+
+            if (Message.isIncomeEnabled(recipient.getPlayer())) {
+                Message.incomeDisable(recipient.getPlayer());
+                sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
 
                 return true;
             }
 
-            Message.incomeEnable(recipient);
-            sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnableOther(Objects.requireNonNull(recipient.getName())));
+            Message.incomeEnable(recipient.getPlayer());
+            sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
 
             return true;
         }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
+import pro.cloudnode.smp.cloudnodemsg.error.NeverJoinedError;
 import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
 import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
@@ -25,6 +26,7 @@ public class ToggleMessageCommand extends Command {
             if (Message.isIncomeEnabled(recipient)) {
                 Message.incomeDisable(recipient);
                 sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Objects.requireNonNull(recipient.getName())));
+            if (recipient.getPlayer() == null) return new NeverJoinedError(Optional.ofNullable(recipient.getName()).orElse("Unknown Player")).send(sender);
 
                 return true;
             }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -29,29 +29,21 @@ public final class ToggleMessageCommand extends Command {
 
             if (Message.isIncomingEnabled(recipient.getPlayer())) {
                 Message.incomingDisable(recipient.getPlayer());
-                sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
-
-                return true;
+                return sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
             }
 
             Message.incomingEnable(recipient.getPlayer());
-            sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
-
-            return true;
+            return sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnableOther(Optional.of(recipient.getPlayer().getName()).orElse("Unknown Player")));
         }
         if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
 
         if (Message.isIncomingEnabled(player)) {
             Message.incomingDisable(player);
-            sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisable());
-
-            return true;
+            return sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisable());
         }
 
         Message.incomingEnable(player);
-        sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnable());
-
-        return true;
+        return sendMessage(sender, CloudnodeMSG.getInstance().config().toggleEnable());
     }
 
     @Override

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -36,4 +36,8 @@ public class ToggleMessageCommand extends Command {
         return true;
     }
 
+    @Override
+    public @Nullable List<String> onTabComplete(@NotNull CommandSender commandSender, org.bukkit.command.@NotNull Command command, @NotNull String s, @NotNull String[] strings) {
+        return null;
+    }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -1,4 +1,16 @@
 package pro.cloudnode.smp.cloudnodemsg.command;
 
-public class ToggleMessageCommand {
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+import pro.cloudnode.smp.cloudnodemsg.Permission;
+import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
+import pro.cloudnode.smp.cloudnodemsg.message.Message;
+
+import java.util.List;
+import java.util.Objects;
+
+public class ToggleMessageCommand extends Command {
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -34,6 +34,7 @@ public class ToggleMessageCommand extends Command {
 
             return true;
         }
+        if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
 
         if (Message.isIncomeEnabled(player)) {
             Message.incomeDisable(player);

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -14,4 +14,26 @@ import java.util.Objects;
 
 public class ToggleMessageCommand extends Command {
     public static final @NotNull String usage = "<player>";
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, org.bukkit.command.@NotNull Command command, @NotNull String label, @NotNull String[] args) {
+        if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
+        if (args.length == 1) {
+            final @NotNull OfflinePlayer recipient = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
+
+            Message.setNoIncoming(recipient);
+            sendMessage(sender, Message.getNoIncoming(recipient) ?
+                    CloudnodeMSG.getInstance().config().toggleDisableOther(Objects.requireNonNull(recipient.getName())) :
+                    CloudnodeMSG.getInstance().config().toggleEnableOther(Objects.requireNonNull(recipient.getName()))
+            );
+            return true;
+        }
+
+        Message.setNoIncoming(Objects.requireNonNull(Message.offlinePlayer(sender)));
+        sendMessage(sender, Message.getNoIncoming(Message.offlinePlayer(sender)) ?
+                CloudnodeMSG.getInstance().config().toggleDisable() :
+                CloudnodeMSG.getInstance().config().toggleEnable()
+        );
+        return true;
+    }
+
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -19,7 +19,6 @@ public class ToggleMessageCommand extends Command {
     @Override
     public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
         if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
-        if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
         if (args.length == 1) {
             final @NotNull Player recipient = Objects.requireNonNull(CloudnodeMSG.getInstance().getServer().getPlayer(args[0]));
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -1,12 +1,13 @@
 package pro.cloudnode.smp.cloudnodemsg.command;
 
-import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
 import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
+import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
 import java.util.List;
@@ -18,6 +19,7 @@ public class ToggleMessageCommand extends Command {
     @Override
     public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String[] args) {
         if (!sender.hasPermission(Permission.TOGGLE) || (args.length == 1 && !sender.hasPermission(Permission.TOGGLE_OTHER))) return new NoPermissionError().send(sender);
+        if (!(sender instanceof final @NotNull Player player)) return new NotPlayerError().send(sender);
         if (args.length == 1) {
             final @NotNull OfflinePlayer recipient = CloudnodeMSG.getInstance().getServer().getOfflinePlayer(args[0]);
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -1,0 +1,4 @@
+package pro.cloudnode.smp.cloudnodemsg.command;
+
+public class ToggleMessageCommand {
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -12,6 +12,7 @@ import pro.cloudnode.smp.cloudnodemsg.error.NoPermissionError;
 import pro.cloudnode.smp.cloudnodemsg.error.NotPlayerError;
 import pro.cloudnode.smp.cloudnodemsg.message.Message;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,6 +56,8 @@ public class ToggleMessageCommand extends Command {
 
     @Override
     public @Nullable List<String> onTabComplete(@NotNull CommandSender sender, org.bukkit.command.@NotNull Command command, @NotNull String s, @NotNull String[] strings) {
-        return null;
+        if (sender.hasPermission(Permission.TOGGLE_OTHER))
+            return null;
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -22,7 +22,7 @@ public class ToggleMessageCommand extends Command {
         if (args.length == 1) {
             final @NotNull Player recipient = Objects.requireNonNull(CloudnodeMSG.getInstance().getServer().getPlayer(args[0]));
 
-            if (!Message.isIncomeEnabled(recipient)) {
+            if (Message.isIncomeEnabled(recipient)) {
                 Message.incomeDisable(recipient);
                 sendMessage(sender, CloudnodeMSG.getInstance().config().toggleDisableOther(Objects.requireNonNull(recipient.getName())));
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ToggleMessageCommand.java
@@ -13,4 +13,5 @@ import java.util.List;
 import java.util.Objects;
 
 public class ToggleMessageCommand extends Command {
+    public static final @NotNull String usage = "<player>";
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/PlayerHasIncomingDisabledError.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/error/PlayerHasIncomingDisabledError.java
@@ -1,0 +1,10 @@
+package pro.cloudnode.smp.cloudnodemsg.error;
+
+import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
+
+public class PlayerHasIncomingDisabledError extends Error {
+    public PlayerHasIncomingDisabledError(final @NotNull String player) {
+        super(CloudnodeMSG.getInstance().config().incomingDisabled(player));
+    }
+}

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -143,7 +143,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
     }
 
     public static boolean getNoIncoming(final @NotNull OfflinePlayer player) {
-        return Objects.requireNonNull(Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer()
-                .get(INCOMING_ENABLED, PersistentDataType.BOOLEAN));
+        return Objects.requireNonNullElse(Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer()
+                .get(INCOMING_ENABLED, PersistentDataType.BOOLEAN), false);
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -145,5 +145,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, false);
     }
 
+    public static boolean isIncomeEnabled(final @NotNull Player player) {
+        return player.getPersistentDataContainer().getOrDefault(INCOMING_ENABLED, PersistentDataType.BOOLEAN, true);
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -141,7 +141,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
      *
      * @param player The player
      */
-    public static void incomeEnable(final @NotNull Player player) {
+    public static void incomingEnable(final @NotNull Player player) {
         player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, true);
     }
 
@@ -150,7 +150,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
      *
      * @param player The player
      */
-    public static void incomeDisable(final @NotNull Player player) {
+    public static void incomingDisable(final @NotNull Player player) {
         player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, false);
     }
 
@@ -159,7 +159,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
      *
      * @param player The player
      */
-    public static boolean isIncomeEnabled(final @NotNull Player player) {
+    public static boolean isIncomingEnabled(final @NotNull Player player) {
         return player.getPersistentDataContainer().getOrDefault(INCOMING_ENABLED, PersistentDataType.BOOLEAN, true);
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -139,7 +139,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
 
     public static void setNoIncoming(final @NotNull OfflinePlayer player) {
         final @NotNull PersistentDataContainer container = Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer();
-        container.set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, Objects.requireNonNull(container.get(INCOMING_ENABLED, PersistentDataType.BOOLEAN)).equals(false));
+        container.set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, !getNoIncoming(player));
     }
 
     public static boolean getNoIncoming(final @NotNull OfflinePlayer player) {

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -5,6 +5,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -81,4 +82,8 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
 
     public static final @NotNull NamespacedKey INCOMING_ENABLED = new NamespacedKey(CloudnodeMSG.getInstance(), "incoming_enabled");
 
+    public static void setNoIncoming(final @NotNull OfflinePlayer player) {
+        final @NotNull PersistentDataContainer container = Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer();
+        container.set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, Objects.requireNonNull(container.get(INCOMING_ENABLED, PersistentDataType.BOOLEAN)).equals(false));
+    }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -78,4 +78,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         else if (player.isOnline())
             Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer().remove(REPLY_TO);
     }
+
+    public static final @NotNull NamespacedKey INCOMING_ENABLED = new NamespacedKey(CloudnodeMSG.getInstance(), "incoming_enabled");
+
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -5,14 +5,12 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
 import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
-import pro.cloudnode.smp.cloudnodemsg.error.PlayerHasIncomingDisabledError;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -136,14 +136,29 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
 
     public static final @NotNull NamespacedKey INCOMING_ENABLED = new NamespacedKey(CloudnodeMSG.getInstance(), "incoming_enabled");
 
+    /**
+     * Allows player to receive private messages
+     *
+     * @param player The player
+     */
     public static void incomeEnable(final @NotNull Player player) {
         player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, true);
     }
 
+    /**
+     * Denies player to receive private messages
+     *
+     * @param player The player
+     */
     public static void incomeDisable(final @NotNull Player player) {
         player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, false);
     }
 
+    /**
+     * Check if a player allows private messages
+     *
+     * @param player The player
+     */
     public static boolean isIncomeEnabled(final @NotNull Player player) {
         return player.getPersistentDataContainer().getOrDefault(INCOMING_ENABLED, PersistentDataType.BOOLEAN, true);
     }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -12,6 +12,7 @@ import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.cloudnodemsg.CloudnodeMSG;
 import pro.cloudnode.smp.cloudnodemsg.Permission;
 import pro.cloudnode.smp.cloudnodemsg.error.InvalidPlayerError;
+import pro.cloudnode.smp.cloudnodemsg.error.PlayerHasIncomingDisabledError;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -86,4 +86,9 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         final @NotNull PersistentDataContainer container = Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer();
         container.set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, Objects.requireNonNull(container.get(INCOMING_ENABLED, PersistentDataType.BOOLEAN)).equals(false));
     }
+
+    public static boolean getNoIncoming(final @NotNull OfflinePlayer player) {
+        return Objects.requireNonNull(Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer()
+                .get(INCOMING_ENABLED, PersistentDataType.BOOLEAN));
+    }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -137,13 +137,13 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
 
     public static final @NotNull NamespacedKey INCOMING_ENABLED = new NamespacedKey(CloudnodeMSG.getInstance(), "incoming_enabled");
 
-    public static void setNoIncoming(final @NotNull OfflinePlayer player) {
-        final @NotNull PersistentDataContainer container = Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer();
-        container.set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, !getNoIncoming(player));
+    public static void incomeEnable(final @NotNull Player player) {
+        player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, true);
     }
 
-    public static boolean getNoIncoming(final @NotNull OfflinePlayer player) {
-        return Objects.requireNonNullElse(Objects.requireNonNull(player.getPlayer()).getPersistentDataContainer()
-                .get(INCOMING_ENABLED, PersistentDataType.BOOLEAN), false);
+    public static void incomeDisable(final @NotNull Player player) {
+        player.getPersistentDataContainer().set(INCOMING_ENABLED, PersistentDataType.BOOLEAN, false);
+    }
+
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -81,3 +81,8 @@ errors:
     # Placeholders:
     #  <player> - the player's username
     never-joined: "<red>(!) <gray><player></gray> has never joined this server.</red>"
+
+    # Target player have disabled their incoming private messages.
+    # Placeholders:
+    #  <player> - the player's username
+    incoming-disabled: "<red>(!) <gray><player></gray> has disabled their private messages."

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -21,6 +21,18 @@ usage: "<yellow>(!) Usage:</yellow> <white>/<command> <usage></white>"
 # Plugin reloaded
 reloaded: "<green>(!) Plugin successfully reloaded.</green>"
 
+# Disable private messages
+togglemsg-disable: "<green>(!) You will not receive private messages anymore.</green>"
+# Placeholders:
+#   <player> - the player's username
+togglemsg-disable-other: "<green>(!) The player <gray><player></gray> will not receive private messages anymore.</green>"
+
+# Enable private messages
+togglemsg-enable: "<green>(!) You will be able to receive private messages now.</green>"
+# Placeholders:
+#   <player> - the player's username
+togglemsg-enable-other: "<green>(!) The player <gray><player></gray> will be able to receive private messages now.</green>"
+
 # Error messages
 errors:
     # No permission

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,17 +30,19 @@ usage: "<yellow>(!) Usage:</yellow> <white>/<command> <usage></white>"
 # Plugin reloaded
 reloaded: "<green>(!) Plugin successfully reloaded.</green>"
 
-# Disable private messages
-toggle-message-disable: "<green>(!) You will not receive private messages anymore.</green>"
-# Placeholders:
-#  <player> - the player's username
-toggle-message-disable-other: "<green>(!) The player <gray><player></gray> will not receive private messages anymore.</green>"
-
-# Enable private messages
-toggle-message-enable: "<green>(!) You will be able to receive private messages now.</green>"
-# Placeholders:
-#  <player> - the player's username
-toggle-message-enable-other: "<green>(!) The player <gray><player></gray> will be able to receive private messages now.</green>"
+toggle:
+    disable:
+        # Disable private messages
+        message: "<yellow>(!) You've disabled private messages. Run again to re-enable.</yellow>"
+        # Placeholders:
+        #  <player> - the player's username
+        other: "<green>(!) Disabled private messages for <gray><player></gray>.</green>"
+    enable:
+        # Enable private messages
+        message: "<green>(!) You can now receive private messages again.</green>"
+        # Placeholders:
+        #  <player> - the player's username
+        other: "<green>(!) Re-enabled private messages for <gray><player></gray>.</green>"
 
 # Error messages
 errors:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,16 +31,16 @@ usage: "<yellow>(!) Usage:</yellow> <white>/<command> <usage></white>"
 reloaded: "<green>(!) Plugin successfully reloaded.</green>"
 
 # Disable private messages
-togglemsg-disable: "<green>(!) You will not receive private messages anymore.</green>"
+toggle-message-disable: "<green>(!) You will not receive private messages anymore.</green>"
 # Placeholders:
-#   <player> - the player's username
-togglemsg-disable-other: "<green>(!) The player <gray><player></gray> will not receive private messages anymore.</green>"
+#  <player> - the player's username
+toggle-message-disable-other: "<green>(!) The player <gray><player></gray> will not receive private messages anymore.</green>"
 
 # Enable private messages
-togglemsg-enable: "<green>(!) You will be able to receive private messages now.</green>"
+toggle-message-enable: "<green>(!) You will be able to receive private messages now.</green>"
 # Placeholders:
-#   <player> - the player's username
-togglemsg-enable-other: "<green>(!) The player <gray><player></gray> will be able to receive private messages now.</green>"
+#  <player> - the player's username
+toggle-message-enable-other: "<green>(!) The player <gray><player></gray> will be able to receive private messages now.</green>"
 
 # Error messages
 errors:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,6 +24,6 @@ commands:
         usage: /<command> <player>
         aliases: [ "unblock" ]
     togglemsg:
-        description: Toggles a private message channel
+        description: Toggles private messages from a player
         usage: /<command> <player>
         aliases: [ "toggledms", "togglepms" ]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -15,3 +15,7 @@ commands:
     cloudnodemsg:
         description: CloudnodeMSG
         usage: /<command>
+    togglemsg:
+        description: Toggles a private message channel
+        usage: /<command> <player>
+        aliases: [ "toggledms", "togglepms" ]


### PR DESCRIPTION
This pull request implements an option for players to opt to use or not private messages.

The following permissions were created for this addition:
- `cloudnodemsg.toggle` -> Gives permission to player to use `/togglemsg`.
- `cloudnodemsg.toggle.other` -> Gives permission to player to change the toggle status of other players using `/togglemsg <player>`.
- `cloudnodemsg.toggle.bypass` -> Any player with this permission can send a private message regardless of the recipient toggle status.

In `Message` there are three methods that this pull request implements:
- `incomeEnable` -> Enables private messages for the player.
- `incomeDisable` -> Disables private messages for the player.
- `isIncomeEnabled` -> Returns a boolean of the status of the player's toggled option.

The command implementation is inside the class `ToggleMessageCommand`.