### PR TITLE
Add DM channels

### DIFF
--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -28,11 +28,11 @@ public final class PluginConfig {
      * @param recipient The username of the message recipient
      * @param message The message text
      */
-    public @NotNull Component incoming(final @NotNull String sender, final @NotNull String recipient, final @NotNull String message) {
+    public @NotNull Component incoming(final @NotNull String sender, final @NotNull String recipient, final @NotNull Component message) {
         return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("incoming"))
                 .replace("<sender>", sender)
                 .replace("<recipient>", recipient),
-                Placeholder.unparsed("message", message)
+                Placeholder.component("message", message)
         );
     }
 
@@ -49,11 +49,11 @@ public final class PluginConfig {
      * @param recipient The username of the message recipient
      * @param message The message text
      */
-    public @NotNull Component outgoing(final @NotNull String sender, final @NotNull String recipient, final @NotNull String message) {
+    public @NotNull Component outgoing(final @NotNull String sender, final @NotNull String recipient, final @NotNull Component message) {
         return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("outgoing"))
                         .replace("<sender>", sender)
                         .replace("<recipient>", recipient),
-                Placeholder.unparsed("message", message)
+                Placeholder.component("message", message)
         );
     }
 

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/PluginConfig.java
@@ -84,6 +84,63 @@ public final class PluginConfig {
     }
 
     /**
+     * Message channel created
+     * <p>Placeholders:</p>
+     * <ul>
+     *     <li>{@code <sender>} - the username of the message sender</li>
+     *     <li>{@code <recipient>} - the username of the message recipient</li>
+     *     <li>{@code <command>} - the command used, e.g. `msg`, `dm`, etc.</li>
+     * </ul>
+     *
+     * @param sender The username of the message sender
+     * @param recipient The username of the message recipient
+     * @param command The command used, e.g. `msg`, `dm`, etc.
+     */
+    public @NotNull Component channelCreated(final @NotNull String sender, final @NotNull String recipient, final @NotNull String command) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("channel.created"))
+                        .replace("<sender>", sender)
+                        .replace("<recipient>", recipient)
+                        .replace("<command>", command));
+    }
+
+    /**
+     * Message channel closed
+     * <p>Placeholders:</p>
+     * <ul>
+     *     <li>{@code <sender>} - the username of the message sender</li>
+     *     <li>{@code <recipient>} - the username of the message recipient</li>
+     *     <li>{@code <command>} - the command used, e.g. `msg`, `dm`, etc.</li>
+     * </ul>
+     *
+     * @param sender The username of the message sender
+     * @param recipient The username of the message recipient
+     * @param command The command used, e.g. `msg`, `dm`, etc.
+     */
+    public @NotNull Component channelClosed(final @NotNull String sender, final @NotNull String recipient, final @NotNull String command) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("channel.closed"))
+                        .replace("<sender>", sender)
+                        .replace("<recipient>", recipient)
+                        .replace("<command>", command));
+    }
+
+    /**
+     * Message channel player is offline and channel closed
+     * <p>Placeholders:</p>
+     * <ul>
+     *     <li>{@code <sender>} - the username of the message sender</li>
+     *     <li>{@code <recipient>} - the username of the message recipient</li>
+     * </ul>
+     *
+     * @param sender The username of the message sender
+     * @param recipient The username of the message recipient
+     */
+    public @NotNull Component channelOffline(final @NotNull String sender, final @NotNull String recipient) {
+        return MiniMessage.miniMessage().deserialize(Objects.requireNonNull(config.getString("channel.offline"))
+                        .replace("<sender>", sender)
+                        .replace("<recipient>", recipient));
+    }
+
+    /**
      * Command usage format
      * <p>Placeholders:</p>
      * <ul>

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -88,6 +88,7 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
     }
 
     public static final @NotNull NamespacedKey IGNORED_PLAYERS = new NamespacedKey(CloudnodeMSG.getInstance(), "ignored");
+    public static final @NotNull NamespacedKey CHANNEL_RECIPIENT = new NamespacedKey(CloudnodeMSG.getInstance(), "channel-recipient");
 
     /**
      * Get UUID set of ignored players from PDC string
@@ -132,5 +133,34 @@ public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer reci
         final @NotNull HashSet<@NotNull UUID> ignoredPlayers = getIgnored(player);
         ignoredPlayers.remove(ignored.getUniqueId());
         player.getPersistentDataContainer().set(IGNORED_PLAYERS, PersistentDataType.STRING, String.join(";", ignoredPlayers.stream().map(UUID::toString).toList()));
+    }
+
+    /**
+     * Create DM channel to player
+     *
+     * @param player    The player (you)
+     * @param recipient The other end of the channel
+     */
+    public static void createChannel(final @NotNull Player player, final @NotNull OfflinePlayer recipient) {
+        player.getPersistentDataContainer().set(CHANNEL_RECIPIENT, PersistentDataType.STRING, recipient.getUniqueId().toString());
+    }
+
+    /**
+     * Exit DM channel
+     *
+     * @param player The player (you)
+     */
+    public static void exitChannel(final @NotNull Player player) {
+        player.getPersistentDataContainer().remove(CHANNEL_RECIPIENT);
+    }
+
+    /**
+     * Get DM channel recipient
+     *
+     * @param player The player
+     */
+    public static @NotNull Optional<@NotNull OfflinePlayer> getChannel(final @NotNull Player player) {
+        return Optional.ofNullable(player.getPersistentDataContainer().get(CHANNEL_RECIPIENT, PersistentDataType.STRING))
+                .map(uuid -> CloudnodeMSG.getInstance().getServer().getOfflinePlayer(UUID.fromString(uuid)));
     }
 }

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -18,7 +18,20 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-public record Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer recipient, @NotNull String message) {
+public final class Message {
+    private final @NotNull OfflinePlayer sender;
+    private final @NotNull OfflinePlayer recipient;
+    private final @NotNull Component message;
+
+    public Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer recipient, @NotNull Component message) {
+        this.sender = sender;
+        this.recipient = recipient;
+        this.message = message;
+    }
+
+    public Message(@NotNull OfflinePlayer sender, @NotNull OfflinePlayer recipient, @NotNull String message) {
+        this(sender, recipient, Component.text(message));
+    }
 
     private @NotNull String playerOrServerUsername(final @NotNull OfflinePlayer player) throws InvalidPlayerError {
         if (player.getUniqueId().equals(console.getUniqueId()))

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -5,7 +5,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -47,13 +47,16 @@ public final class Message {
         final @NotNull String senderUsername = playerOrServerUsername(this.sender);
         final @NotNull String recipientUsername = playerOrServerUsername(this.recipient);
 
+        final @NotNull Optional<@NotNull Player> senderPlayer = Optional.ofNullable(this.sender.getPlayer());
+        final @NotNull Optional<@NotNull Player> recipientPlayer = Optional.ofNullable(this.recipient.getPlayer());
+
         sendMessage(sender, CloudnodeMSG.getInstance().config().outgoing(senderUsername, recipientUsername, message));
         setReplyTo(sender, recipient);
 
         if (
-                (recipient.isOnline() && Message.isIgnored(Objects.requireNonNull(recipient.getPlayer()), sender))
+                (recipientPlayer.isPresent() && Message.isIgnored(recipientPlayer.get(), sender))
                 &&
-                (sender.isOnline() && !Objects.requireNonNull(sender.getPlayer()).hasPermission(Permission.IGNORE_BYPASS))
+                (senderPlayer.isPresent() && !senderPlayer.get().hasPermission(Permission.IGNORE_BYPASS))
         ) return;
         sendMessage(recipient, CloudnodeMSG.getInstance().config()
                 .incoming(senderUsername, recipientUsername, message));

--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/message/Message.java
@@ -51,7 +51,8 @@ public final class Message {
         final @NotNull Optional<@NotNull Player> recipientPlayer = Optional.ofNullable(this.recipient.getPlayer());
 
         sendMessage(sender, CloudnodeMSG.getInstance().config().outgoing(senderUsername, recipientUsername, message));
-        setReplyTo(sender, recipient);
+        if (senderPlayer.isPresent() && !Message.hasChannel(senderPlayer.get(), recipient))
+            setReplyTo(sender, recipient);
 
         if (
                 (recipientPlayer.isPresent() && Message.isIgnored(recipientPlayer.get(), sender))
@@ -60,7 +61,8 @@ public final class Message {
         ) return;
         sendMessage(recipient, CloudnodeMSG.getInstance().config()
                 .incoming(senderUsername, recipientUsername, message));
-        setReplyTo(recipient, sender);
+        if (recipientPlayer.isPresent() && !Message.hasChannel(recipientPlayer.get(), sender))
+            setReplyTo(recipient, sender);
     }
 
     public final static @NotNull OfflinePlayer console = CloudnodeMSG.getInstance().getServer()
@@ -178,5 +180,16 @@ public final class Message {
     public static @NotNull Optional<@NotNull OfflinePlayer> getChannel(final @NotNull Player player) {
         return Optional.ofNullable(player.getPersistentDataContainer().get(CHANNEL_RECIPIENT, PersistentDataType.STRING))
                 .map(uuid -> CloudnodeMSG.getInstance().getServer().getOfflinePlayer(UUID.fromString(uuid)));
+    }
+
+    /**
+     * Check whether player has DM channel with recipient
+     *
+     * @param player The player
+     * @param recipient The recipient
+     */
+    public static boolean hasChannel(final @NotNull Player player, final @NotNull OfflinePlayer recipient) {
+        final @NotNull Optional<@NotNull OfflinePlayer> channel = getChannel(player);
+        return channel.isPresent() && channel.get().getUniqueId().equals(recipient.getUniqueId());
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,8 +31,10 @@ channel:
     closed: <yellow>(!) Your chat messages will now be <gray>public</gray>.</yellow>
 
     # Message channel player is offline and channel closed
-    # Same placeholders as created
-    offline: <red>(!) Player <gray><player></gray> is offline. Your chat messages have been switched back to <gray>public</gray>.</red>
+    # Placeholders:
+    #  <sender> - the username of the message sender
+    #  <recipient> - the username of the message recipient
+    offline: <red>(!) Player <gray><recipient></gray> is offline. Your chat messages have been switched back to <gray>public</gray>.</red>
 
 # Name for console/server that should appear as <sender> or <recipient> in messages
 console-name: "Server"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,22 @@ ignored: "<green>(!) You will no longer see messages from <gray><player></gray>.
 # Same placeholders as ignored
 unignored: "<yellow>(!) You are no longer ignoring <gray><player></gray>.</yellow>"
 
+channel:
+    # Message channel created
+    # Placeholders:
+    #  <sender> - the username of the message sender
+    #  <recipient> - the username of the message recipient
+    #  <command> - the command used, e.g. `msg`, `dm`, etc.
+    created: <green>(!) Your chat messages will now be sent as private messages to <gray><recipient></gray>. To re-enable public messages, run <click:suggest_command:/<command> <recipient>><gray>/<command> <recipient></gray></click></green>
+
+    # Message channel closed
+    # Same placeholders as created
+    closed: <yellow>(!) Your chat messages will now be <gray>public</gray>.</yellow>
+
+    # Message channel player is offline and channel closed
+    # Same placeholders as created
+    offline: <red>(!) Player <gray><player></gray> is offline. Your chat messages have been switched back to <gray>public</gray>.</red>
+
 # Name for console/server that should appear as <sender> or <recipient> in messages
 console-name: "Server"
 


### PR DESCRIPTION
Adds direct message channels. This lets you send private messages to a player without having to type a command every time.

By running `/msg <player>` (without a message) you create a message channel. All messages you write in chat are sent privately to the player instead of the public. You can return to global chat by running the same command again.

When you have a DM channel with a player, your `/reply` (`/r`) is not set to them, allowing you to reply to other players that message you.