### PR TITLE
Fix replying to console messages

### DIFF
--- a/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
+++ b/src/main/java/pro/cloudnode/smp/cloudnodemsg/command/ReplyCommand.java
@@ -27,7 +27,7 @@ public final class ReplyCommand extends Command {
 
         final @NotNull Optional<@NotNull OfflinePlayer> recipient = Message.getReplyTo(Message.offlinePlayer(sender));
         if (recipient.isEmpty()) return new NobodyReplyError().send(sender);
-        if (!Message.isIncomingEnabled(Objects.requireNonNull(recipient.get().getPlayer())) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(Objects.requireNonNull(recipient.get().getName())).send(sender);
+        if (!recipient.get().getUniqueId().equals(Message.console.getUniqueId()) && !Message.isIncomingEnabled(Objects.requireNonNull(recipient.get().getPlayer())) && !sender.hasPermission(Permission.TOGGLE_BYPASS)) return new PlayerHasIncomingDisabledError(Objects.requireNonNull(recipient.get().getName())).send(sender);
         if (
             !recipient.get().getUniqueId().equals(Message.console.getUniqueId())
             && (


### PR DESCRIPTION
When replying to a message, it's possible that `recipient.getPlayer()` will return null if the recipient is console.

This PR checks if the recipient is console before trying to get player.